### PR TITLE
addition of SMTP_SENDER environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This is a small, self-hosted Go application that acts as a (mostly) drop-in repl
 | `SMTP_PORT`         | SMTP port (usually `587`)                                                                                                                   |
 | `SMTP_USERNAME`     | SMTP login username                                                                                                                         |
 | `SMTP_PASSWORD`     | SMTP login password or app key                                                                                                              |
+| `SMTP_SENDER`       | SMTP sender, may need to be different from SMTP_USERNAME for certain providers                                                              |
 | `RECIPIENT_EMAIL`   | Email address to receive form submissions                                                                                                   |
 | `PORT`              | Port to run the server on (default: `8080`)                                                                                                 |
 | `CORS_ALLOW_ORIGIN` | CORS allowed origin (default: `*`)                                                                                                          |
@@ -29,10 +30,10 @@ This is a small, self-hosted Go application that acts as a (mostly) drop-in repl
 
 ## Example HTML Form
 
-Note that the script needs to be *only* on the pages that have forms and not loaded on the entire site, and should be loaded after the form. 
-This script will load a signed timestamp-based token that will need to be included in the form that needs to be included in the submission. 
+Note that the script needs to be *only* on the pages that have forms and not loaded on the entire site, and should be loaded after the form.
+This script will load a signed timestamp-based token that will need to be included in the form that needs to be included in the submission.
 It expires in 15 minutes. This could create some false positives, for example, if a visitor went to the site and took more than 15 minutes to make their comment.  
-The time range can be adjusted in the code, or you could warn them on the page that the form expires in 15 minutes. 
+The time range can be adjusted in the code, or you could warn them on the page that the form expires in 15 minutes.
 It also doesn't allow it to be posted within 2 seconds, as that will most likely be a bot.   
 
 ```html
@@ -70,6 +71,7 @@ SMTP_HOST=smtp.example.com \
 SMTP_PORT=587 \
 SMTP_USERNAME=your@domain.com \
 SMTP_PASSWORD=yourpassword \
+SMTP_USERNAME=your@other-domain.com \
 RECIPIENT_EMAIL=you@domain.com \
 PORT=8080 \
 CORS_ALLOW_ORIGIN=https://yourhugo.site \

--- a/main.go
+++ b/main.go
@@ -63,16 +63,17 @@ func sendEmail(name, email, message string) error {
 	smtpPort := os.Getenv("SMTP_PORT")
 	smtpUser := os.Getenv("SMTP_USERNAME")
 	smtpPass := os.Getenv("SMTP_PASSWORD")
+	smtpSender := os.Getenv("SMTP_SENDER")
 	recipient := os.Getenv("RECIPIENT_EMAIL")
 
-	if smtpHost == "" || smtpPort == "" || smtpUser == "" || smtpPass == "" || recipient == "" {
+	if smtpHost == "" || smtpPort == "" || smtpUser == "" || smtpPass == "" || smtpSender == "" || recipient == "" {
 		return fmt.Errorf("missing required SMTP environment variables")
 	}
 
 	body := fmt.Sprintf("From: %s\nTo: %s\nSubject: Contact Form Submission\n\nName: %s\nEmail: %s\nMessage:\n%s",
-		smtpUser, recipient, name, email, message)
+		smtpSender, recipient, name, email, message)
 	auth := smtp.PlainAuth("", smtpUser, smtpPass, smtpHost)
-	return smtp.SendMail(smtpHost+":"+smtpPort, auth, smtpUser, []string{recipient}, []byte(body))
+	return smtp.SendMail(smtpHost+":"+smtpPort, auth, smtpSender, []string{recipient}, []byte(body))
 }
 
 func contactHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# Add SMTP_SENDER environment variable for Brevo (and surely other) compatibility

## Problem
Brevo SMTP service doesn't allow using the SMTP user for both SMTP authentication (SMTP_USERNAME) and as the sender address. This was causing issues when sending emails through Brevo (and will most likely be similar for other services).

## Solution
- Added new `SMTP_SENDER` environment variable to specify the sender email address separately from the authentication username
- Updated `sendEmail()` function to use `SMTP_SENDER` for the email From header and sender parameter
- Added validation to ensure `SMTP_SENDER` is provided

## Changes
- Modified `sendEmail()` function in `main.go`:
  - Added `SMTP_SENDER` environment variable
  - Updated environment variable validation to include `SMTP_SENDER`
  - Changed email body From field to use `smtpSender` instead of `smtpUser`
  - Updated `smtp.SendMail()` call to use `smtpSender` as sender parameter

## Testing
- [ ] Verify `SMTP_SENDER` environment variable is properly read
- [ ] Confirm email sending works with Brevo SMTP
- [ ] Test that missing `SMTP_SENDER` returns appropriate error

## Environment Variables
After this change, the following environment variables are required:
- `SMTP_HOST` - SMTP server hostname
- `SMTP_PORT` - SMTP server port
- `SMTP_USERNAME` - SMTP authentication username
- `SMTP_PASSWORD` - SMTP authentication password
- `SMTP_SENDER` - Email address to use as sender (**NEW**)
- `RECIPIENT_EMAIL` - Email address to receive contact form submissions

## Breaking Changes
This is a breaking change that requires adding the new `SMTP_SENDER` environment variable to your deployment configuration. Alternatively, SMTP_USERNAME could be used as fallback in case SMTP_SENDER is not provided.
